### PR TITLE
Feat: [Swift] BOJ11005 - 진법 변환 2

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		76A72AD22D475A690050A3C9 /* 1152.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A72AD12D475A690050A3C9 /* 1152.swift */; };
 		76B60DA12D570E1200052E23 /* 2563.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B60DA02D570E1200052E23 /* 2563.swift */; };
 		76B60DA32D58827000052E23 /* 2745.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B60DA22D58827000052E23 /* 2745.swift */; };
+		76B60DA52D58FE4F00052E23 /* 11005.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B60DA42D58FE4F00052E23 /* 11005.swift */; };
 		76FFB2C42D48C057005E948F /* 2908.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFB2C32D48C057005E948F /* 2908.swift */; };
 		76FFB2C62D49D541005E948F /* 5622.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFB2C52D49D541005E948F /* 5622.swift */; };
 		76FFB2C82D4B1A4E005E948F /* 3003.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFB2C72D4B1A4E005E948F /* 3003.swift */; };
@@ -169,6 +170,7 @@
 		76B51B8C2D0D73D400F5AD22 /* 11382.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11382.swift; sourceTree = "<group>"; };
 		76B60DA02D570E1200052E23 /* 2563.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2563.swift; sourceTree = "<group>"; };
 		76B60DA22D58827000052E23 /* 2745.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2745.swift; sourceTree = "<group>"; };
+		76B60DA42D58FE4F00052E23 /* 11005.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11005.swift; sourceTree = "<group>"; };
 		76FCDF302D08799F00E47010 /* Algorithm_Swift */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Algorithm_Swift; sourceTree = BUILT_PRODUCTS_DIR; };
 		76FCDF4F2D087FDD00E47010 /* 1000.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1000.swift; sourceTree = "<group>"; };
 		76FCDF5B2D088A3200E47010 /* 1001.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1001.swift; sourceTree = "<group>"; };
@@ -343,6 +345,7 @@
 			isa = PBXGroup;
 			children = (
 				76B60DA22D58827000052E23 /* 2745.swift */,
+				76B60DA42D58FE4F00052E23 /* 11005.swift */,
 			);
 			path = "8. 일반 수학 1";
 			sourceTree = "<group>";
@@ -543,6 +546,7 @@
 				762B87CB2D2158DD00884CE1 /* 10699.swift in Sources */,
 				762B87E62D24DD6600884CE1 /* 11718.swift in Sources */,
 				76B60DA32D58827000052E23 /* 2745.swift in Sources */,
+				76B60DA52D58FE4F00052E23 /* 11005.swift in Sources */,
 				762B87D02D2159E000884CE1 /* 10950.swift in Sources */,
 				76FFB2C62D49D541005E948F /* 5622.swift in Sources */,
 				76A72A932D2B90CD0050A3C9 /* 18108.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/8. 일반 수학 1/11005.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/8. 일반 수학 1/11005.swift
@@ -1,0 +1,44 @@
+//
+//  11005.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 2/10/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/11005
+//  알고리즘 분류: 수학, 구현
+
+//import Foundation
+
+class BOJ11005: Solvable {
+    // 메모리: 79512KB, 시간: 12ms, 코드 길이: 772B
+    func run() {
+        // 입력 받기
+        if let input = readLine()?.split(separator: " "),
+           let N = Int(input[0]),
+           let B = Int(input[1]) {
+
+            var number = N
+            var result = ""
+
+            // 10진법 수를 B진법으로 변환
+            while number > 0 {
+                let remainder = number % B // B로 나눈 나머지
+                let convertedChar: String
+
+                if remainder < 10 {
+                    convertedChar = String(remainder) // 0~9는 그대로 숫자
+                } else {
+                    let asciiValue = Character("A").asciiValue! + UInt8(remainder - 10)
+                    convertedChar = String(UnicodeScalar(asciiValue))
+                }
+
+                result = convertedChar + result // 결과 문자열 앞에 추가
+                number /= B // B로 나누기
+            }
+
+            // 결과 출력
+            print(result)
+        }
+    }
+}

--- a/Swift/Algorithm_Swift/BOJ/단계별/8. 일반 수학 1/2745.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/8. 일반 수학 1/2745.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 class BOJ2745: Solvable {
-    // 메모리: 79516KB, 시간: 8ms, 코드 길이: 838B
+    // 메모리: 79512KB, 시간: 12ms, 코드 길이: 880B
     func run() {
         // 입력 받기
         if let input = readLine()?.split(separator: " "), let B = Int(input[1]) {

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ2745()
+let main = BOJ11005()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #67 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ11005 - 진법 변환 2
- **사용 알고리즘**: 진법 변환, 나눗셈을 이용한 변환
- **시간 복잡도**: $O(log_B N)$
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/11005)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/5.svg" height="20px" /> Bronze I

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. 입력 받기
    - `readLine()`을 통해 한 줄 입력을 받음.
    - `split(separator: " ")`를 사용하여 공백 기준으로 `N`(10진수 값)과 `B`(변환할 진법)를 분리.
    - `N`: 변환할 10진수 값.
    - `B`: 목표 진법 값.
2. 10진법 수를 B진법으로 변환
    - `number`: 변환할 값을 저장하는 변수.
    - `result`: 변환된 결과를 저장하는 문자열.
    - 반복문 실행 (number > 0인 동안):
        - `number % B`: B진법으로 변환할 때 현재 자리의 값 구하기.
        - `if remainder < 10`: 0~9이면 그대로 문자열로 변환.
        - `else`: 10 이상이면 `A~Z`로 변환 (`A`의 ASCII 값 활용).
        - `result = convertedChar + result`: 앞쪽에 추가해 변환된 숫자 순서를 맞춤.
        - `number /= B`: 다음 자리 계산을 위해 B로 나누기.
3. 결과 출력
    - 변환된 B진법 값을 출력.

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
// 10진법 수를 B진법으로 변환
while number > 0 {
    let remainder = number % B // B로 나눈 나머지
    let convertedChar: String

    if remainder < 10 {
        convertedChar = String(remainder) // 0~9는 그대로 숫자
    } else {
        let asciiValue = Character("A").asciiValue! + UInt8(remainder - 10)
        convertedChar = String(UnicodeScalar(asciiValue))
    }

    result = convertedChar + result // 결과 문자열 앞에 추가
    number /= B // B로 나누기
}
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
