### PR TITLE
Feat: [Swift] BOJ11729 - 하노이 탑 이동 순서

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		76FFB7FC2D94F8ED00F2B678 /* 1269.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFB7FB2D94F8ED00F2B678 /* 1269.swift */; };
 		76FFB8002D9654FF00F2B678 /* 11478.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFB7FF2D9654FF00F2B678 /* 11478.swift */; };
 		C92146F02DC4F46C008EE715 /* 2447.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92146EF2DC4F46C008EE715 /* 2447.swift */; };
+		C92146F22DC5D021008EE715 /* 11729.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92146F12DC5D021008EE715 /* 11729.swift */; };
 		C923EB742DB7A8AD00BF7FB3 /* 1037.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923EB732DB7A8AD00BF7FB3 /* 1037.swift */; };
 		C97392AA2DBCABD600DD9B39 /* 20920.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97392A92DBCABD600DD9B39 /* 20920.swift */; };
 		C97392AC2DBDB75800DD9B39 /* 27433.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97392AB2DBDB75800DD9B39 /* 27433.swift */; };
@@ -351,6 +352,7 @@
 		76FFB7FB2D94F8ED00F2B678 /* 1269.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1269.swift; sourceTree = "<group>"; };
 		76FFB7FF2D9654FF00F2B678 /* 11478.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11478.swift; sourceTree = "<group>"; };
 		C92146EF2DC4F46C008EE715 /* 2447.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2447.swift; sourceTree = "<group>"; };
+		C92146F12DC5D021008EE715 /* 11729.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11729.swift; sourceTree = "<group>"; };
 		C923EB732DB7A8AD00BF7FB3 /* 1037.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1037.swift; sourceTree = "<group>"; };
 		C97392A92DBCABD600DD9B39 /* 20920.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 20920.swift; sourceTree = "<group>"; };
 		C97392AB2DBDB75800DD9B39 /* 27433.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 27433.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				C9CF39D02DC264F80025603C /* 24060.swift */,
 				C9D3AFC02DC3A05E00A94E56 /* 4779.swift */,
 				C92146EF2DC4F46C008EE715 /* 2447.swift */,
+				C92146F12DC5D021008EE715 /* 11729.swift */,
 			);
 			path = "19. 재귀";
 			sourceTree = "<group>";
@@ -1176,6 +1179,7 @@
 				76FFB2C62D49D541005E948F /* 5622.swift in Sources */,
 				765A98502DB3AFDA00B167EA /* 24723.swift in Sources */,
 				765A98522DB4B0E700B167EA /* 11050.swift in Sources */,
+				C92146F22DC5D021008EE715 /* 11729.swift in Sources */,
 				76DB4FEE2D7A98F30085165E /* 1018.swift in Sources */,
 				76A72A932D2B90CD0050A3C9 /* 18108.swift in Sources */,
 				76A72AB62D34C2610050A3C9 /* 25314.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/19. 재귀/11729.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/19. 재귀/11729.swift
@@ -1,0 +1,46 @@
+//
+//  11729.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 5/3/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/11729
+//  알고리즘 분류: 재귀
+
+import Foundation
+
+class BOJ11729: Solvable {
+    // 메모리: 87388KB, 시간: 244ms, 코드 길이: 850B
+    func run() {
+        // 재귀적으로 하노이 탑 이동 과정을 문자열에 버퍼링합니다.
+        func solveHanoi(_ n: Int, _ from: Int, _ to: Int, _ aux: Int, _ buffer: inout String) {
+            if n == 1 {
+                // 원판 1개는 바로 from -> to
+                buffer += "\(from) \(to)\n"
+                return
+            }
+            // n-1개를 from에서 aux로 옮기기
+            solveHanoi(n - 1, from, aux, to, &buffer)
+            // 가장 큰 원판을 from에서 to로
+            buffer += "\(from) \(to)\n"
+            // n-1개를 aux에서 to로 옮기기
+            solveHanoi(n - 1, aux, to, from, &buffer)
+        }
+
+        guard let line = readLine(), let N = Int(line) else {
+            exit(0)
+        }
+
+        // 이동 횟수는 2^N - 1
+        let moves = (1 << N) - 1
+
+        // 결과 문자열 버퍼
+        var output = "\(moves)\n"
+        // 이동 과정 기록
+        solveHanoi(N, 1, 3, 2, &output)
+
+        // 한 번에 출력
+        print(output, terminator: "")
+    }
+}

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ2447()
+let main = BOJ11729()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #343 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ11729 - 하노이 탑 이동 순서
- **사용 알고리즘**: 분할 정복 (재귀)
- **시간 복잡도**: $O(2^N)$ (출력 크기에 비례)
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/11729)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/11.svg" height="20px" /> Gold V

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. 입력 처리
    - `readLine()`으로 원판 개수 `N`을 읽고, `Int`로 안전하게 변환합니다.
    - 실패 시 프로그램을 종료합니다.
2. 이동 횟수 계산
    - 하노이 탑의 최소 이동 횟수는 $2^N−1$입니다.
    - 비트 시프트로 효율적으로 계산합니다.
3. 재귀 함수 `solveHanoi`
    - 기저 사례: `n == 1`이면 단일 이동을 기록하고 반환합니다.
    - 재귀 단계:
        1. 위의 `n-1`개를 보조 기둥(aux)으로 이동
        2. 가장 큰 원판을 목표 기둥(to)으로 이동
        3. 보조 기둥의 `n-1`개를 목표 기둥으로 이동
4. 출력 버퍼링 및 한 번 출력
    - 이동 횟수와 이동 내역을 모두 문자열에 누적한 뒤 한 번에 출력해 I/O 오버헤드를 최소화합니다.

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
// 재귀적으로 하노이 탑 이동 과정을 문자열에 버퍼링합니다.
func solveHanoi(_ n: Int, _ from: Int, _ to: Int, _ aux: Int, _ buffer: inout String) {
    if n == 1 {
        // 원판 1개는 바로 from -> to
        buffer += "\(from) \(to)\n"
        return
    }
    // n-1개를 from에서 aux로 옮기기
    solveHanoi(n - 1, from, aux, to, &buffer)
    // 가장 큰 원판을 from에서 to로
    buffer += "\(from) \(to)\n"
    // n-1개를 aux에서 to로 옮기기
    solveHanoi(n - 1, aux, to, from, &buffer)
}
```
```swift
guard let line = readLine(), let N = Int(line) else {
    exit(0)
}

// 이동 횟수는 2^N - 1
let moves = (1 << N) - 1

// 결과 문자열 버퍼
var output = "\(moves)\n"
// 이동 과정 기록
solveHanoi(N, 1, 3, 2, &output)

// 한 번에 출력
print(output, terminator: "")
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
