### PR TITLE
Feat: [Swift] BOJ2565 - 전깃줄

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		C91329392DD059DA003692C5 /* 14889.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91329382DD059DA003692C5 /* 14889.swift */; };
 		C919D2D12DE04A5200F59A72 /* 11053.swift in Sources */ = {isa = PBXBuildFile; fileRef = C919D2D02DE04A5200F59A72 /* 11053.swift */; };
 		C919D2D32DE0E4B400F59A72 /* 11054.swift in Sources */ = {isa = PBXBuildFile; fileRef = C919D2D22DE0E4B400F59A72 /* 11054.swift */; };
+		C919D2D52DE31FC900F59A72 /* 2565.swift in Sources */ = {isa = PBXBuildFile; fileRef = C919D2D42DE31FC900F59A72 /* 2565.swift */; };
 		C91A10C82DD5D1C900086324 /* 9461.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91A10C72DD5D1C900086324 /* 9461.swift */; };
 		C91A10CA2DD768C400086324 /* 1912.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91A10C92DD768C400086324 /* 1912.swift */; };
 		C91A10CC2DD87FBE00086324 /* 1149.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91A10CB2DD87FBE00086324 /* 1149.swift */; };
@@ -382,6 +383,7 @@
 		C91329382DD059DA003692C5 /* 14889.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 14889.swift; sourceTree = "<group>"; };
 		C919D2D02DE04A5200F59A72 /* 11053.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11053.swift; sourceTree = "<group>"; };
 		C919D2D22DE0E4B400F59A72 /* 11054.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11054.swift; sourceTree = "<group>"; };
+		C919D2D42DE31FC900F59A72 /* 2565.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2565.swift; sourceTree = "<group>"; };
 		C91A10C72DD5D1C900086324 /* 9461.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 9461.swift; sourceTree = "<group>"; };
 		C91A10C92DD768C400086324 /* 1912.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1912.swift; sourceTree = "<group>"; };
 		C91A10CB2DD87FBE00086324 /* 1149.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1149.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 				C91A10D52DDF21FE00086324 /* 2156.swift */,
 				C919D2D02DE04A5200F59A72 /* 11053.swift */,
 				C919D2D22DE0E4B400F59A72 /* 11054.swift */,
+				C919D2D42DE31FC900F59A72 /* 2565.swift */,
 			);
 			path = "21. 동적 계획법 1";
 			sourceTree = "<group>";
@@ -1361,6 +1364,7 @@
 				76DB4FDE2D743E9E0085165E /* 24264.swift in Sources */,
 				76DB4FEC2D796A9C0085165E /* 19532.swift in Sources */,
 				76A72ACE2D44A1B10050A3C9 /* 10809.swift in Sources */,
+				C919D2D52DE31FC900F59A72 /* 2565.swift in Sources */,
 				76DB4FD42D6F7C800085165E /* 10101.swift in Sources */,
 				762B87BD2D21535B00884CE1 /* 1330.swift in Sources */,
 				76DB4FD22D6E34B30085165E /* 9063.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/21. 동적 계획법 1/2565.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/21. 동적 계획법 1/2565.swift
@@ -1,0 +1,45 @@
+//
+//  2565.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 5/25/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/2565
+//  알고리즘 분류: 다이나믹 프로그래밍
+
+class BOJ2565: Solvable {
+    // 메모리: 79516KB, 시간: 12ms, 코드 길이: 588B
+    func run() {
+        // 빠른 입출력
+        let fileIO = RhynoFileIO()
+
+        // 입력 처리
+        let N = fileIO.readInt()
+        var wires = [(a: Int, b: Int)]()
+        wires.reserveCapacity(N)
+        for _ in 0..<N {
+            wires.append((fileIO.readInt(), fileIO.readInt()))
+        }
+
+        // A 전봇대 기준으로 정렬
+        wires.sort { $0.a < $1.a }
+
+        // B 번호들만 뽑아서 LIS 길이 구하기
+        let B = wires.map { $0.b }
+        var dp = [Int](repeating: 1, count: N)
+        var lis = 1
+
+        for i in 0..<N {
+            for j in 0..<i {
+                if B[j] < B[i] {
+                    dp[i] = max(dp[i], dp[j] + 1)
+                }
+            }
+            lis = max(lis, dp[i])
+        }
+
+        // 제거할 전깃줄 수 = 전체 N - 남길 수 있는 최대 교차 없는 전깃줄 수 (LIS)
+        print(N - lis)
+    }
+}

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ11054()
+let main = BOJ2565()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #418 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ2565 - 전깃줄
- **사용 알고리즘**: DP (다이나믹 프로그래밍)
- **시간 복잡도**: $O(n^2)$
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/2565)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/11.svg" height="20px" /> Gold V

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. 입력 처리
    - `RhynoFileIO` 로 전깃줄 개수 `N`을 읽고, A–B 연결 정보를 `(a,b)` 튜플 배열에 저장합니다.
2. 정렬
    - A 쪽 위치가 오름차순이 되도록 정렬합니다. 이렇게 하면 A 간에는 교차가 없고, B 기준으로만 교차 여부가 결정됩니다.
3. LIS 계산
    - B 배열만 뽑아 $O(N^2)$ DP로 최장증가부분수열 길이 `lis`를 구합니다.
    - `dp[i]` 는 “끝이 `B[i]` 인 LIS” 의 길이입니다.
4. 정답 출력
    - 전체 전깃줄 수에서 교차 없이 남길 수 있는 최대 수(`lis`)를 빼면, 최소 제거해야 할 전깃줄 수가 나옵니다.

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
// 빠른 입출력
let fileIO = RhynoFileIO()

// 입력 처리
let N = fileIO.readInt()
var wires = [(a: Int, b: Int)]()
wires.reserveCapacity(N)
for _ in 0..<N {
    wires.append((fileIO.readInt(), fileIO.readInt()))
}

// A 전봇대 기준으로 정렬
wires.sort { $0.a < $1.a }

// B 번호들만 뽑아서 LIS 길이 구하기
let B = wires.map { $0.b }
var dp = [Int](repeating: 1, count: N)
var lis = 1

for i in 0..<N {
    for j in 0..<i {
        if B[j] < B[i] {
            dp[i] = max(dp[i], dp[j] + 1)
        }
    }
    lis = max(lis, dp[i])
}

// 제거할 전깃줄 수 = 전체 N - 남길 수 있는 최대 교차 없는 전깃줄 수 (LIS)
print(N - lis)
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
