### PR TITLE
Feat: [Swift] BOJ10986 - 나머지 합

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		76FFB7FC2D94F8ED00F2B678 /* 1269.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFB7FB2D94F8ED00F2B678 /* 1269.swift */; };
 		76FFB8002D9654FF00F2B678 /* 11478.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFB7FF2D9654FF00F2B678 /* 11478.swift */; };
 		C9009F412DE9709400ED6F27 /* 16139.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9009F402DE9709400ED6F27 /* 16139.swift */; };
+		C9009F432DEA5B0000ED6F27 /* 10986.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9009F422DEA5B0000ED6F27 /* 10986.swift */; };
 		C910CC812DD339B60080892B /* 9184.swift in Sources */ = {isa = PBXBuildFile; fileRef = C910CC802DD339B60080892B /* 9184.swift */; };
 		C910CC832DD470460080892B /* 1904.swift in Sources */ = {isa = PBXBuildFile; fileRef = C910CC822DD470460080892B /* 1904.swift */; };
 		C913292F2DC9DC97003692C5 /* 15651.swift in Sources */ = {isa = PBXBuildFile; fileRef = C913292E2DC9DC97003692C5 /* 15651.swift */; };
@@ -379,6 +380,7 @@
 		76FFB7FB2D94F8ED00F2B678 /* 1269.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1269.swift; sourceTree = "<group>"; };
 		76FFB7FF2D9654FF00F2B678 /* 11478.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11478.swift; sourceTree = "<group>"; };
 		C9009F402DE9709400ED6F27 /* 16139.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 16139.swift; sourceTree = "<group>"; };
+		C9009F422DEA5B0000ED6F27 /* 10986.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 10986.swift; sourceTree = "<group>"; };
 		C910CC802DD339B60080892B /* 9184.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 9184.swift; sourceTree = "<group>"; };
 		C910CC822DD470460080892B /* 1904.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1904.swift; sourceTree = "<group>"; };
 		C913292E2DC9DC97003692C5 /* 15651.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 15651.swift; sourceTree = "<group>"; };
@@ -510,6 +512,7 @@
 				C955557A2DE6BC2000C9C3B5 /* 11659.swift */,
 				C99444272DE81F1200644B24 /* 2559.swift */,
 				C9009F402DE9709400ED6F27 /* 16139.swift */,
+				C9009F422DEA5B0000ED6F27 /* 10986.swift */,
 			);
 			path = "22. 누적 합";
 			sourceTree = "<group>";
@@ -1304,6 +1307,7 @@
 				760956D42D9E55E600E5507D /* 1929.swift in Sources */,
 				7669740A2D641DC200DE5E4D /* 9506.swift in Sources */,
 				C955557B2DE6BC2000C9C3B5 /* 11659.swift in Sources */,
+				C9009F432DEA5B0000ED6F27 /* 10986.swift in Sources */,
 				76A72ABC2D38EBFD0050A3C9 /* 2439.swift in Sources */,
 				762B87C52D21577C00884CE1 /* 2753.swift in Sources */,
 				7679C7242D4DD64900D56B9C /* 10988.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/22. 누적 합/10986.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/22. 누적 합/10986.swift
@@ -1,0 +1,46 @@
+//
+//  10986.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 5/31/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/10986
+//  알고리즘 분류: 수학, 누적 합
+
+class BOJ10986: Solvable {
+    // 메모리: 98640KB, 시간: 120ms, 코드 길이: 654B
+    func run() {
+        // 빠른 입출력 설정
+        let fileIO = RhynoFileIO()
+
+        // 입력 처리
+        let N = fileIO.readInt()    // 수열의 길이 (1 ≤ N ≤ 1e6)
+        let M = fileIO.readInt()    // 나누는 수 (2 ≤ M ≤ 1e3)
+
+        // 모듈로 빈도 배열 및 초기값
+        // freq[r] = 지금까지 누적합 % M == r 가 나온 횟수
+        var freq = [Int](repeating: 0, count: M)
+        var sumMod = 0
+        freq[0] = 1  // 빈 구간(처음)도 하나의 누적합 0
+
+        // 누적합 % M 계산 및 빈도 집계
+        for _ in 0..<N {
+            let a = fileIO.readInt()
+            sumMod = (sumMod + (a % M)) % M
+            freq[sumMod] += 1
+        }
+
+        // 동일한 모듈로가 나온 쌍의 수 계산
+        // C(freq[r], 2) = freq[r] * (freq[r] - 1) / 2
+        var answer: Int64 = 0
+        for f in freq {
+            if f >= 2 {
+                answer += Int64(f) * Int64(f - 1) / 2
+            }
+        }
+
+        // 결과 출력
+        print(answer)
+    }
+}

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ16139()
+let main = BOJ10986()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #434 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ10986 - 나머지 합
- **사용 알고리즘**: 누적 합, 조합
- **시간 복잡도**: $O(n + m)$ (n: 수열 길이, m: 나누는 수)
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/10986)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/13.svg" height="20px" /> Gold III

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. **입력 처리**
    - `RhynoFileIO`로 빠르게 입력을 읽어옵니다.
        - `N`: 수열의 길이
        - `M`: 나눌 값
2. **모듈로 빈도 배열 초기화**
    - `freq[r]`는 지금까지 누적합을 `M`으로 나눈 나머지가 r인 횟수
    - 빈 구간(초기 누적합 0) 대응으로 `freq[0] = 1` 세팅
3. **누적합 % M 계산 및 빈도 집계**
    - 각 입력값을 누적하여 `sumMod` 갱신하고, 해당 나머지의 빈도를 올립니다.
4. **조합 수 계산**
    - 같은 나머지가 나온 인덱스 쌍의 수 = `C(f, 2)`를 더합니다.
5. **결과 출력**

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
import Foundation

// 빠른 입출력 설정
let fileIO = RhynoFileIO()

// 입력 처리
let N = fileIO.readInt()    // 수열의 길이 (1 ≤ N ≤ 1e6)
let M = fileIO.readInt()    // 나누는 수 (2 ≤ M ≤ 1e3)

// 모듈로 빈도 배열 및 초기값
// freq[r] = 지금까지 누적합 % M == r 가 나온 횟수
var freq = [Int](repeating: 0, count: M)
var sumMod = 0
freq[0] = 1  // 빈 구간(처음)도 하나의 누적합 0

// 누적합 % M 계산 및 빈도 집계
for _ in 0..<N {
    let a = fileIO.readInt()
    sumMod = (sumMod + (a % M)) % M
    freq[sumMod] += 1
}

// 동일한 모듈로가 나온 쌍의 수 계산
// C(freq[r], 2) = freq[r] * (freq[r] - 1) / 2
var answer: Int64 = 0
for f in freq {
    if f >= 2 {
        answer += Int64(f) * Int64(f - 1) / 2
    }
}

// 결과 출력
print(answer)
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
