### PR TITLE
Feat: [Swift] BOJ25682 - 체스판 다시 칠하기 2

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		C9009F412DE9709400ED6F27 /* 16139.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9009F402DE9709400ED6F27 /* 16139.swift */; };
 		C9009F432DEA5B0000ED6F27 /* 10986.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9009F422DEA5B0000ED6F27 /* 10986.swift */; };
 		C9009F452DEC1AE000ED6F27 /* 11660.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9009F442DEC1AE000ED6F27 /* 11660.swift */; };
+		C9009F472DED062700ED6F27 /* 25682.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9009F462DED062700ED6F27 /* 25682.swift */; };
 		C910CC812DD339B60080892B /* 9184.swift in Sources */ = {isa = PBXBuildFile; fileRef = C910CC802DD339B60080892B /* 9184.swift */; };
 		C910CC832DD470460080892B /* 1904.swift in Sources */ = {isa = PBXBuildFile; fileRef = C910CC822DD470460080892B /* 1904.swift */; };
 		C913292F2DC9DC97003692C5 /* 15651.swift in Sources */ = {isa = PBXBuildFile; fileRef = C913292E2DC9DC97003692C5 /* 15651.swift */; };
@@ -383,6 +384,7 @@
 		C9009F402DE9709400ED6F27 /* 16139.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 16139.swift; sourceTree = "<group>"; };
 		C9009F422DEA5B0000ED6F27 /* 10986.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 10986.swift; sourceTree = "<group>"; };
 		C9009F442DEC1AE000ED6F27 /* 11660.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11660.swift; sourceTree = "<group>"; };
+		C9009F462DED062700ED6F27 /* 25682.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 25682.swift; sourceTree = "<group>"; };
 		C910CC802DD339B60080892B /* 9184.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 9184.swift; sourceTree = "<group>"; };
 		C910CC822DD470460080892B /* 1904.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1904.swift; sourceTree = "<group>"; };
 		C913292E2DC9DC97003692C5 /* 15651.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 15651.swift; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 				C9009F402DE9709400ED6F27 /* 16139.swift */,
 				C9009F422DEA5B0000ED6F27 /* 10986.swift */,
 				C9009F442DEC1AE000ED6F27 /* 11660.swift */,
+				C9009F462DED062700ED6F27 /* 25682.swift */,
 			);
 			path = "22. 누적 합";
 			sourceTree = "<group>";
@@ -1234,6 +1237,7 @@
 				762B87C42D21571A00884CE1 /* 2743.swift in Sources */,
 				762B87D92D215D0200884CE1 /* 2754.swift in Sources */,
 				C97392AC2DBDB75800DD9B39 /* 27433.swift in Sources */,
+				C9009F472DED062700ED6F27 /* 25682.swift in Sources */,
 				76A72AC02D3B97E90050A3C9 /* 2562.swift in Sources */,
 				765A985A2DC0A75D00B167EA /* 25501.swift in Sources */,
 				76DB4FE22D7449FF0085165E /* 24266.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/22. 누적 합/25682.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/22. 누적 합/25682.swift
@@ -1,0 +1,83 @@
+//
+//  25682.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 6/2/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/25682
+//  알고리즘 분류: 누적 합
+
+class BOJ25682: Solvable {
+    // 메모리: 118832KB, 시간: 244ms, 코드 길이: 2053B
+    func run() {
+        // 빠른 입출력 설정
+        let fileIO = RhynoFileIO()
+
+        // 입력 처리: N행, M열, K를 읽음
+        let N = fileIO.readInt()
+        let M = fileIO.readInt()
+        let K = fileIO.readInt()
+
+        // 보드 입력: 1-based 편의를 위해 row 1..N, col 1..M 으로 저장
+        // board[i][j]: 'W' 또는 'B' 에 대응하는 UInt8 값을 저장 ('W' = 87, 'B' = 66)
+        var board = [[UInt8]](repeating: [UInt8](repeating: 0, count: M + 1), count: N + 1)
+        for i in 1...N {
+            // 문자열 전체를 한 번에 읽어서 [UInt8]으로 저장
+            // 예: "WBWB" → [87,66,87,66]
+            let rowBytes = fileIO.readByteSequenceWithoutSpaceAndLineFeed()
+            for j in 1...M {
+                board[i][j] = rowBytes[j - 1]
+            }
+        }
+
+        // whiteError[i][j] 계산:
+        // (i+j)%2 == 0 이면 기대 색 = 'W', else = 'B'.
+        // 만약 board[i][j] != 기대색(white-start) 이면 1, 같으면 0
+        //
+        // whiteError 에 대해 2D prefixSum을 만든다.
+        // prefix[i][j] = (1,1)부터 (i,j)까지의 whiteError 합
+        var prefix = [[Int]](repeating: [Int](repeating: 0, count: M + 1), count: N + 1)
+
+        for i in 1...N {
+            var rowSum = 0
+            for j in 1...M {
+                // 기대 색이 'W'인지 'B'인지 확인
+                let expected: UInt8 = ((i + j) & 1) == 0 ? UInt8(UInt8(ascii: "W")) : UInt8(UInt8(ascii: "B"))
+                let isMismatch = (board[i][j] != expected) ? 1 : 0
+                rowSum += isMismatch
+                // 위(prefix[i-1][j]) + 현재 행 누적(rowSum)
+                prefix[i][j] = prefix[i - 1][j] + rowSum
+            }
+        }
+
+        // 모든 K×K 부분판을 검사하면서 최소로 칠해야 할 칸 수를 구함
+        // 부분판 (r,c)부터 (r+K-1, c+K-1) 일 때 whiteMismatch =
+        //   S = prefix[r+K-1][c+K-1]
+        //     - prefix[r-1][c+K-1]
+        //     - prefix[r+K-1][c-1]
+        //     + prefix[r-1][c-1]
+        // blackMismatch = K*K - whiteMismatch
+        //
+        // 두 값 중 작은 것을 정답 후보로 삼고, 최종적으로 최소값을 출력
+        var answer = Int.max
+        let area = K * K
+
+        for r in 1...N - K + 1 {
+            let r2 = r + K - 1
+            for c in 1...M - K + 1 {
+                let c2 = c + K - 1
+                // 2D 누적합을 이용해 (r..r2, c..c2) 구간의 white-error 합
+                let whiteMismatch = prefix[r2][c2]
+                                  - prefix[r - 1][c2]
+                                  - prefix[r2][c - 1]
+                                  + prefix[r - 1][c - 1]
+                let blackMismatch = area - whiteMismatch
+                answer = min(answer, whiteMismatch, blackMismatch)
+            }
+        }
+
+        // 결과 출력
+        print(answer)
+    }
+}

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ11660()
+let main = BOJ25682()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #438 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ25682 - 체스판 다시 칠하기 2
- **사용 알고리즘**: 누적 합
- **시간 복잡도**: $O(n×m)$
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/25682)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/12.svg" height="20px" /> Gold IV

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. 입력 처리
    - 보드의 행 수 `N` (1 ≤ N ≤ 2000)
    - 보드의 열 수 `M` (1 ≤ M ≤ 2000)
    - 잘라낼 체스판 크기 `K` (1 ≤ K ≤ min(N,M))
2. 보드 저장
    - 1-based 인덱스를 쓰기 위해 배열 크기를 `(N+1)×(M+1)`로 잡았습니다.
    - `readByteSequenceWithoutSpaceAndLineFeed()`는 공백/줄바꿈 제외한 연속된 바이트(=문자) 배열을 리턴합니다.
3. whiteError 및 누적 합 계산
    - `(i+j)%2 == 0`일 때 왼쪽 위부터 흰색(`"W"`)이어야 하므로 기대색을 `"W"`, 그렇지 않으면 `"B"`로 잡습니다.
    - `isMismatch`는 그 칸(`i`,`j`)이 white-start 체스판과 다른지(=다시 칠해야 하는지) 여부(0/1).
    - `rowSum`에는 현재 행 `i`에서 1열부터 `j`열까지 whiteMismatch 개수가 누적되어 들어갑니다.
    - `prefix[i][j] = prefix[i-1][j] + rowSum`:
    → 위쪽 모든 행(`1..i-1`)의 `j`열까지의 오차 합 + 이번 행 `i`의 1열~`j`열 오차 합이 더해져서
    `(1,1)`부터 `(i,j)`까지의 흰색 시작 체스판과의 불일치(=칠할 칸) 총합이 됩니다.
4. K×K 부분판 순회 및 최소 불일치 계산
    - `(r,c)`를 왼쪽 위로 하는 K×K 블록의 범위는 `(r..r2, c..c2)`이며, 이 구간 안에서 white-start 체스판에 일치하지 않는 칸 수를 `whiteMismatch`로 O(1)에 계산합니다.
    - K×K 전체 칸(`area = K*K`) 중 whiteMismatch가 아닌 칸들은 black-start 체스판을 맞추기 위해 칠해야 하는 칸이므로 `blackMismatch = area - whiteMismatch`가 됩니다.
    - 두 값 중 작은 값이 해당 부분판을 체스판으로 만들기 위한 최소 칠할 횟수이고, 전체 부분판 중 최소를 담아 `answer`에 갱신합니다.
5. 결과 출력

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
import Foundation

let fileIO = RhynoFileIO()

// 입력 처리: N행, M열, K를 읽음
let N = fileIO.readInt()
let M = fileIO.readInt()
let K = fileIO.readInt()

// 보드 입력: 1-based 편의를 위해 row 1..N, col 1..M 으로 저장
// board[i][j]: 'W' 또는 'B' 에 대응하는 UInt8 값을 저장 ('W' = 87, 'B' = 66)
var board = [[UInt8]](repeating: [UInt8](repeating: 0, count: M + 1), count: N + 1)
for i in 1...N {
    // 문자열 전체를 한 번에 읽어서 [UInt8]으로 저장
    // 예: "WBWB" → [87,66,87,66]
    let rowBytes = fileIO.readByteSequenceWithoutSpaceAndLineFeed()
    for j in 1...M {
        board[i][j] = rowBytes[j - 1]
    }
}

// whiteError[i][j] 계산: 
// (i+j)%2 == 0 이면 기대 색 = 'W', else = 'B'.
// 만약 board[i][j] != 기대색(white-start) 이면 1, 같으면 0
//
// whiteError 에 대해 2D prefixSum을 만든다.
// prefix[i][j] = (1,1)부터 (i,j)까지의 whiteError 합
var prefix = [[Int]](repeating: [Int](repeating: 0, count: M + 1), count: N + 1)

for i in 1...N {
    var rowSum = 0
    for j in 1...M {
        // 기대 색이 'W'인지 'B'인지 확인
        let expected: UInt8 = ((i + j) & 1) == 0 ? UInt8(UInt8(ascii: "W")) : UInt8(UInt8(ascii: "B"))
        let isMismatch = (board[i][j] != expected) ? 1 : 0
        rowSum += isMismatch
        // 위(prefix[i-1][j]) + 현재 행 누적(rowSum)
        prefix[i][j] = prefix[i - 1][j] + rowSum
    }
}

// 모든 K×K 부분판을 검사하면서 최소로 칠해야 할 칸 수를 구함
// 부분판 (r,c)부터 (r+K-1, c+K-1) 일 때 whiteMismatch = 
//   S = prefix[r+K-1][c+K-1] 
//     - prefix[r-1][c+K-1] 
//     - prefix[r+K-1][c-1] 
//     + prefix[r-1][c-1]
// blackMismatch = K*K - whiteMismatch
//
// 두 값 중 작은 것을 정답 후보로 삼고, 최종적으로 최소값을 출력
var answer = Int.max
let area = K * K

for r in 1...N - K + 1 {
    let r2 = r + K - 1
    for c in 1...M - K + 1 {
        let c2 = c + K - 1
        // 2D 누적합을 이용해 (r..r2, c..c2) 구간의 white-error 합
        let whiteMismatch = prefix[r2][c2]
                          - prefix[r - 1][c2]
                          - prefix[r2][c - 1]
                          + prefix[r - 1][c - 1]
        let blackMismatch = area - whiteMismatch
        answer = min(answer, whiteMismatch, blackMismatch)
    }
}

// 결과 출력
print(answer)
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
