### PR TITLE
Feat: [Swift] BOJ24445 - 알고리즘 수업 - 너비 우선 탐색 2

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		C966CB402E0924AC00CB0AA4 /* MaxHeap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C966CB3F2E0924AC00CB0AA4 /* MaxHeap.swift */; };
 		C96F35102E1255CD00F12A39 /* 24480.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96F350F2E1255CD00F12A39 /* 24480.swift */; };
 		C96F35122E135E0300F12A39 /* 24444.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96F35112E135E0300F12A39 /* 24444.swift */; };
+		C96F359B2E1505FF00F12A39 /* 24445.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96F359A2E1505FF00F12A39 /* 24445.swift */; };
 		C97392AA2DBCABD600DD9B39 /* 20920.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97392A92DBCABD600DD9B39 /* 20920.swift */; };
 		C97392AC2DBDB75800DD9B39 /* 27433.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97392AB2DBDB75800DD9B39 /* 27433.swift */; };
 		C9742C262E0BC00600254991 /* 11286.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9742C252E0BC00600254991 /* 11286.swift */; };
@@ -461,6 +462,7 @@
 		C966CB3F2E0924AC00CB0AA4 /* MaxHeap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxHeap.swift; sourceTree = "<group>"; };
 		C96F350F2E1255CD00F12A39 /* 24480.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 24480.swift; sourceTree = "<group>"; };
 		C96F35112E135E0300F12A39 /* 24444.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 24444.swift; sourceTree = "<group>"; };
+		C96F359A2E1505FF00F12A39 /* 24445.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 24445.swift; sourceTree = "<group>"; };
 		C97392A92DBCABD600DD9B39 /* 20920.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 20920.swift; sourceTree = "<group>"; };
 		C97392AB2DBDB75800DD9B39 /* 27433.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 27433.swift; sourceTree = "<group>"; };
 		C9742C252E0BC00600254991 /* 11286.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11286.swift; sourceTree = "<group>"; };
@@ -654,6 +656,7 @@
 				C9742C5E2E1182C000254991 /* 24479.swift */,
 				C96F350F2E1255CD00F12A39 /* 24480.swift */,
 				C96F35112E135E0300F12A39 /* 24444.swift */,
+				C96F359A2E1505FF00F12A39 /* 24445.swift */,
 			);
 			path = "27. 그래프와 순회";
 			sourceTree = "<group>";
@@ -1417,6 +1420,7 @@
 				762B87CB2D2158DD00884CE1 /* 10699.swift in Sources */,
 				762B87E62D24DD6600884CE1 /* 11718.swift in Sources */,
 				76B60DA32D58827000052E23 /* 2745.swift in Sources */,
+				C96F359B2E1505FF00F12A39 /* 24445.swift in Sources */,
 				76B60DA52D58FE4F00052E23 /* 11005.swift in Sources */,
 				C95B9A102DF41FBE00661A32 /* 13305.swift in Sources */,
 				C9E2FAD32DB90A2800C4355A /* 25192.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/27. 그래프와 순회/24445.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/27. 그래프와 순회/24445.swift
@@ -1,0 +1,74 @@
+//
+//  24445.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 7/2/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/24445
+//  알고리즘 분류: 그래프 이론, 그래프 탐색, 정렬, 너비 우선 탐색
+
+class BOJ24445: Solvable {
+    // 메모리: 92772KB, 시간: 172ms, 코드 길이: 1284B
+    func run() {
+        // 빠른 입출력 설정
+        let fileIO = RhynoFileIO()
+        let n = fileIO.readInt()
+        let m = fileIO.readInt()
+        let r = fileIO.readInt()
+
+        // 인접 리스트 생성
+        var graph: [[Int]] = Array(repeating: [], count: n + 1)
+
+        // 간선 정보 입력
+        for _ in 0..<m {
+            let u = fileIO.readInt()
+            let v = fileIO.readInt()
+            graph[u].append(v)
+            graph[v].append(u)
+        }
+
+        // 각 정점의 인접 리스트를 내림차순으로 정렬
+        for i in 1...n {
+            graph[i].sort(by: >)  // 내림차순 정렬
+        }
+
+        // 방문 순서를 저장할 배열 (0: 방문하지 않음)
+        var visitOrder: [Int] = Array(repeating: 0, count: n + 1)
+        var currentOrder = 1
+
+        // BFS 함수
+        func bfs(_ start: Int) {
+            var queue: [Int] = []
+            
+            // 시작 정점 방문 처리
+            visitOrder[start] = currentOrder
+            currentOrder += 1
+            queue.append(start)
+            
+            var queueIndex = 0  // 큐의 앞부분을 가리키는 인덱스 (dequeue 최적화)
+            
+            while queueIndex < queue.count {
+                let current = queue[queueIndex]  // dequeue
+                queueIndex += 1
+                
+                // 현재 정점의 인접 정점들을 내림차순으로 방문
+                for nextVertex in graph[current] {
+                    if visitOrder[nextVertex] == 0 {  // 방문하지 않은 경우
+                        visitOrder[nextVertex] = currentOrder
+                        currentOrder += 1
+                        queue.append(nextVertex)  // enqueue
+                    }
+                }
+            }
+        }
+
+        // 시작 정점에서 BFS 시작
+        bfs(r)
+
+        // 결과 출력
+        for i in 1...n {
+            print(visitOrder[i])
+        }
+    }
+}

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ24444()
+let main = BOJ24445()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #522 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ24445 - 알고리즘 수업 - 너비 우선 탐색 2
- **사용 알고리즘**: 그래프 탐색 (너비 우선 탐색, BFS)
- **시간 복잡도**: $O(n + m + m log m)$ – 정렬 $O(m log m)$, BFS $O(n + m)$
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/24445)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/9.svg" height="20px" /> Silver II

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. 입력 처리
    - `readInt()` 로 정점 수 N, 간선 수 M, 시작 정점 R 을 순서대로 읽어옵니다.
2. 그래프(인접 리스트) 생성
    - 크기 `n+1` 의 2차원 배열을 만들고, 양방향 간선 `(u,v)` 를 각각 리스트에 추가합니다.
3. 인접 리스트 내림차순 정렬
    - 문제 요구대로 “인접 정점을 내림차순으로” 방문하기 위해 각 리스트를 내림차순으로 정렬합니다.
4. 방문 순서 기록 배열 초기화
    - `visitOrder[v]` 에 정점 v 의 방문 순서를 저장합니다.
    - `currentOrder` 가 다음으로 부여할 순서 번호입니다.
    - 0 은 ‘미방문’을 뜻합니다.
5. BFS 함수
    - 시작점 `start` 를 방문 처리하고 큐에 넣습니다.
    - `queueIndex` 와 배열로 O(1) dequeue/enqueue 를 구현.
    - 꺼낸 정점 `u` 의 인접 리스트(내림차순)에 대해 아직 미방문인 `v` 를 차례로 방문 처리 후 큐에 추가합니다.
6. BFS 실행 및 결과 출력
    - `bfs(r)` 로 R 에서 시작.
    - 1번부터 N번까지 각 정점의 `visitOrder` 를 한 줄씩 출력합니다.
    - 도달 불가능한 정점은 0 으로 남아 있습니다.

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
import Foundation

// 빠른 입출력 설정
let fileIO = RhynoFileIO()
let n = fileIO.readInt()
let m = fileIO.readInt()
let r = fileIO.readInt()

// 인접 리스트 생성
var graph: [[Int]] = Array(repeating: [], count: n + 1)

// 간선 정보 입력
for _ in 0..<m {
    let u = fileIO.readInt()
    let v = fileIO.readInt()
    graph[u].append(v)
    graph[v].append(u)
}

// 각 정점의 인접 리스트를 내림차순으로 정렬
for i in 1...n {
    graph[i].sort(by: >)  // 내림차순 정렬
}

// 방문 순서를 저장할 배열 (0: 방문하지 않음)
var visitOrder: [Int] = Array(repeating: 0, count: n + 1)
var currentOrder = 1

// BFS 함수
func bfs(_ start: Int) {
    var queue: [Int] = []
    
    // 시작 정점 방문 처리
    visitOrder[start] = currentOrder
    currentOrder += 1
    queue.append(start)
    
    var queueIndex = 0  // 큐의 앞부분을 가리키는 인덱스 (dequeue 최적화)
    
    while queueIndex < queue.count {
        let current = queue[queueIndex]  // dequeue
        queueIndex += 1
        
        // 현재 정점의 인접 정점들을 내림차순으로 방문
        for nextVertex in graph[current] {
            if visitOrder[nextVertex] == 0 {  // 방문하지 않은 경우
                visitOrder[nextVertex] = currentOrder
                currentOrder += 1
                queue.append(nextVertex)  // enqueue
            }
        }
    }
}

// 시작 정점에서 BFS 시작
bfs(r)

// 결과 출력
for i in 1...n {
    print(visitOrder[i])
}
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
