### PR TITLE
Feat: [Swift] BOJ3273 - 두 수의 합

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		C92FA9372DF2B0DA00694189 /* 1541.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92FA9362DF2B0DA00694189 /* 1541.swift */; };
 		C9527C962E3073C200BA9168 /* 11404.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9527C952E3073C200BA9168 /* 11404.swift */; };
 		C9527C982E31FDA300BA9168 /* 1956.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9527C972E31FDA300BA9168 /* 1956.swift */; };
+		C9527C9A2E334A2F00BA9168 /* 3273.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9527C992E334A2F00BA9168 /* 3273.swift */; };
 		C955557B2DE6BC2000C9C3B5 /* 11659.swift in Sources */ = {isa = PBXBuildFile; fileRef = C955557A2DE6BC2000C9C3B5 /* 11659.swift */; };
 		C95B9A102DF41FBE00661A32 /* 13305.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95B9A0F2DF41FBE00661A32 /* 13305.swift */; };
 		C95B9A122DF4F3C100661A32 /* 2630.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95B9A112DF4F3C100661A32 /* 2630.swift */; };
@@ -477,6 +478,7 @@
 		C92FA9362DF2B0DA00694189 /* 1541.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1541.swift; sourceTree = "<group>"; };
 		C9527C952E3073C200BA9168 /* 11404.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11404.swift; sourceTree = "<group>"; };
 		C9527C972E31FDA300BA9168 /* 1956.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1956.swift; sourceTree = "<group>"; };
+		C9527C992E334A2F00BA9168 /* 3273.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 3273.swift; sourceTree = "<group>"; };
 		C955557A2DE6BC2000C9C3B5 /* 11659.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11659.swift; sourceTree = "<group>"; };
 		C95B9A0F2DF41FBE00661A32 /* 13305.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 13305.swift; sourceTree = "<group>"; };
 		C95B9A112DF4F3C100661A32 /* 2630.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2630.swift; sourceTree = "<group>"; };
@@ -746,6 +748,7 @@
 		760956EA2DA3583100E5507D /* 30. 투 포인터 */ = {
 			isa = PBXGroup;
 			children = (
+				C9527C992E334A2F00BA9168 /* 3273.swift */,
 			);
 			path = "30. 투 포인터";
 			sourceTree = "<group>";
@@ -1484,6 +1487,7 @@
 				766974042D604ABE00DE5E4D /* 2869.swift in Sources */,
 				76DB4FF62D7F46010085165E /* 2587.swift in Sources */,
 				76DB4FD62D71D4B10085165E /* 5073.swift in Sources */,
+				C9527C9A2E334A2F00BA9168 /* 3273.swift in Sources */,
 				769986E02DAA166700752D17 /* 18258.swift in Sources */,
 				C91329392DD059DA003692C5 /* 14889.swift in Sources */,
 				76A72AB42D3399740050A3C9 /* 25304.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/30. 투 포인터/3273.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/30. 투 포인터/3273.swift
@@ -1,0 +1,47 @@
+//
+//  3273.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 7/25/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/3273
+//  알고리즘 분류: 정렬, 두 포인터
+
+class BOJ3273: Solvable {
+    // 메모리: 81272KB, 시간: 20ms, 코드 길이: 529B
+    func run() {
+        // 빠른 입출력 설정
+        let fileIO = RhynoFileIO()
+        let n = fileIO.readInt()
+        var arr = [Int](repeating: 0, count: n)
+        for i in 0..<n {
+            arr[i] = fileIO.readInt()
+        }
+        let x = fileIO.readInt()
+
+        // 정렬 (두 포인터를 위해)
+        arr.sort()
+
+        // 두 포인터로 쌍 개수 세기
+        var left = 0
+        var right = n - 1
+        var count = 0
+
+        while left < right {
+            let sum = arr[left] + arr[right]
+            if sum == x {
+                count += 1
+                left += 1
+                right -= 1
+            } else if sum < x {
+                left += 1
+            } else {
+                right -= 1
+            }
+        }
+
+        // 결과 출력
+        print(count)
+    }
+}

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ1956()
+let main = BOJ3273()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #587 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ3273 - 두 수의 합
- **사용 알고리즘**: 배열 정렬, 투 포인터
- **시간 복잡도**: $O(n log n)$
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/3273)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/8.svg" width="14px" /> Silver III

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. **입력 처리**
    - `n`을 읽고 크기 `n`짜리 배열을 만든 뒤, 수열의 각 원소를 채웁니다.
    - 마지막으로 목표합 `x`를 읽습니다.
2. **정렬**
    - 두 포인터 기법을 적용하기 위해 배열을 오름차순으로 정렬합니다.
3. **두 포인터로 쌍 세기**
    - `left = 0`, `right = n-1`에서 시작해서
        - `arr[left] + arr[right] == x` 이면 `count++`, 양쪽 포인터 모두 한 칸 안쪽으로 이동
        - 합이 작으면 `left++` (더 큰 값을 만들기 위해)
        - 합이 크면 `right--` (더 작은 값을 만들기 위해)
    - `left < right`일 동안 반복합니다.
4. **출력**
    - 최종적으로 센 `count`를 출력합니다.

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
import Foundation

// 빠른 입출력 설정
let fileIO = RhynoFileIO()
let n = fileIO.readInt()
var arr = [Int](repeating: 0, count: n)
for i in 0..<n {
    arr[i] = fileIO.readInt()
}
let x = fileIO.readInt()

// 정렬 (두 포인터를 위해)
arr.sort()

// 두 포인터로 쌍 개수 세기
var left = 0
var right = n - 1
var count = 0

while left < right {
    let sum = arr[left] + arr[right]
    if sum == x {
        count += 1
        left += 1
        right -= 1
    } else if sum < x {
        left += 1
    } else {
        right -= 1
    }
}

// 결과 출력
print(count)
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
