### PR TITLE
Feat: [Swift] BOJ1644 - 소수의 연속합

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		C92FA9372DF2B0DA00694189 /* 1541.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92FA9362DF2B0DA00694189 /* 1541.swift */; };
 		C94DCBBC2E34B112008788B0 /* 2470.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94DCBBB2E34B112008788B0 /* 2470.swift */; };
 		C94DCBBE2E35E870008788B0 /* 1806.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94DCBBD2E35E870008788B0 /* 1806.swift */; };
+		C94DCBC02E372D17008788B0 /* 1644.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94DCBBF2E372D17008788B0 /* 1644.swift */; };
 		C9527C962E3073C200BA9168 /* 11404.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9527C952E3073C200BA9168 /* 11404.swift */; };
 		C9527C982E31FDA300BA9168 /* 1956.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9527C972E31FDA300BA9168 /* 1956.swift */; };
 		C9527C9A2E334A2F00BA9168 /* 3273.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9527C992E334A2F00BA9168 /* 3273.swift */; };
@@ -480,6 +481,7 @@
 		C92FA9362DF2B0DA00694189 /* 1541.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1541.swift; sourceTree = "<group>"; };
 		C94DCBBB2E34B112008788B0 /* 2470.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2470.swift; sourceTree = "<group>"; };
 		C94DCBBD2E35E870008788B0 /* 1806.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1806.swift; sourceTree = "<group>"; };
+		C94DCBBF2E372D17008788B0 /* 1644.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1644.swift; sourceTree = "<group>"; };
 		C9527C952E3073C200BA9168 /* 11404.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11404.swift; sourceTree = "<group>"; };
 		C9527C972E31FDA300BA9168 /* 1956.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1956.swift; sourceTree = "<group>"; };
 		C9527C992E334A2F00BA9168 /* 3273.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 3273.swift; sourceTree = "<group>"; };
@@ -755,6 +757,7 @@
 				C9527C992E334A2F00BA9168 /* 3273.swift */,
 				C94DCBBB2E34B112008788B0 /* 2470.swift */,
 				C94DCBBD2E35E870008788B0 /* 1806.swift */,
+				C94DCBBF2E372D17008788B0 /* 1644.swift */,
 			);
 			path = "30. 투 포인터";
 			sourceTree = "<group>";
@@ -1608,6 +1611,7 @@
 				762B87CE2D21597B00884CE1 /* 10871.swift in Sources */,
 				76A72ABE2D3A23610050A3C9 /* 10818.swift in Sources */,
 				C91A10D22DDC15AA00086324 /* 1463.swift in Sources */,
+				C94DCBC02E372D17008788B0 /* 1644.swift in Sources */,
 				C919D2D32DE0E4B400F59A72 /* 11054.swift in Sources */,
 				C91329332DCC298A003692C5 /* 9663.swift in Sources */,
 				C96F35122E135E0300F12A39 /* 24444.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/30. 투 포인터/1644.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/30. 투 포인터/1644.swift
@@ -1,0 +1,85 @@
+//
+//  1644.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 7/28/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/1644
+//  알고리즘 분류: 수학, 정수론, 두 포인터, 소수 판정, 에라토스테네스의 체
+
+import Foundation
+
+class BOJ1644: Solvable {
+    // 메모리: 88892KB, 시간: 44ms, 코드 길이: 1792B
+    func run() {
+        /// 에라토스테네스의 체를 이용하여 n까지의 소수를 찾아 배열로 반환합니다.
+        /// - Parameter n: 소수를 찾을 최대 자연수.
+        /// - Returns: n까지의 소수들을 담은 정수 배열.
+        func sieveOfEratosthenes(upTo n: Int) -> [Int] {
+            guard n >= 2 else { return [] } // 2 미만은 소수가 없음
+
+            var isPrime = [Bool](repeating: true, count: n + 1)
+            isPrime[0] = false
+            isPrime[1] = false
+
+            var primes: [Int] = []
+            for i in 2...n {
+                if isPrime[i] {
+                    primes.append(i)
+                    for j in stride(from: i * 2, through: n, by: i) {
+                        isPrime[j] = false
+                    }
+                }
+            }
+            return primes
+        }
+
+        /// 주어진 targetN을 연속된 소수들의 합으로 나타낼 수 있는 경우의 수를 계산합니다.
+        /// - Parameters:
+        ///   - targetN: 목표 자연수.
+        ///   - primes: 소수들을 담은 배열 (오름차순).
+        /// - Returns: targetN을 연속된 소수들의 합으로 나타낼 수 있는 경우의 수.
+        func countContinuousPrimeSums(targetN: Int, primes: [Int]) -> Int {
+            var start = 0
+            var end = 0
+            var currentSum = 0
+            var count = 0
+
+            // primes 배열이 비어있으면 0을 반환 (예: targetN이 1인 경우)
+            guard !primes.isEmpty else { return 0 }
+
+            while true {
+                if currentSum >= targetN {
+                    // 현재 합이 targetN보다 크거나 같으면 start 포인터를 이동하여 합을 줄임
+                    currentSum -= primes[start]
+                    start += 1
+                } else if end == primes.count {
+                    // end 포인터가 소수 배열의 끝에 도달하면 종료
+                    break
+                } else {
+                    // 현재 합이 targetN보다 작으면 end 포인터를 이동하여 합을 늘림
+                    currentSum += primes[end]
+                    end += 1
+                }
+
+                // 현재 합이 targetN과 같으면 경우의 수 증가
+                if currentSum == targetN {
+                    count += 1
+                }
+            }
+            return count
+        }
+
+        // 메인 실행 로직
+        let fileIO = RhynoFileIO()
+        let N = fileIO.readInt()
+
+        // N까지의 소수 리스트 생성
+        let primes = sieveOfEratosthenes(upTo: N)
+
+        // 연속된 소수 합의 경우의 수 계산 및 출력
+        let result = countContinuousPrimeSums(targetN: N, primes: primes)
+        print(result)
+    }
+}

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ1806()
+let main = BOJ1644()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #597 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ1644 - 소수의 연속합
- **사용 알고리즘**: 에라토스테네스의 체, 투 포인터
- **시간 복잡도**: $O(N log log N)$
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/1644)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/13.svg" height="20px" /> Gold III

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. 소수 목록 생성 (에라토스테네스의 체)
    - 2부터 n까지 `isPrime` 불리언 배열에서 배수 지워가며 소수만 `primes`에 수집
2. 투 포인터로 연속 소수 합 세기
    - `start`, `end` 인덱스로 `(start, end)` 구간 합 유지
    - 합이 목표 이상이면 `start++`, 미만이면 `end++`
    - `합 == 목표`일 때마다 카운트++
3. 결과 출력
    - 입력 N 읽고, 소수 리스트 만든 뒤 연속 합 경우의 수 출력

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
import Foundation

/// 에라토스테네스의 체를 이용하여 n까지의 소수를 찾아 배열로 반환합니다.
func sieveOfEratosthenes(upTo n: Int) -> [Int] {
    guard n >= 2 else { return [] } // 2 미만은 소수가 없음

    var isPrime = [Bool](repeating: true, count: n + 1)
    isPrime[0] = false
    isPrime[1] = false

    var primes: [Int] = []
    for i in 2...n {
        if isPrime[i] {
            primes.append(i)
            for j in stride(from: i * 2, through: n, by: i) {
                isPrime[j] = false
            }
        }
    }
    return primes
}

/// 주어진 targetN을 연속된 소수들의 합으로 나타낼 수 있는 경우의 수를 계산합니다.
func countContinuousPrimeSums(targetN: Int, primes: [Int]) -> Int {
    var start = 0
    var end = 0
    var currentSum = 0
    var count = 0

    // primes 배열이 비어있으면 0을 반환 (예: targetN이 1인 경우)
    guard !primes.isEmpty else { return 0 }

    while true {
        if currentSum >= targetN {
            // 현재 합이 targetN보다 크거나 같으면 start 포인터를 이동하여 합을 줄임
            currentSum -= primes[start]
            start += 1
        } else if end == primes.count {
            // end 포인터가 소수 배열의 끝에 도달하면 종료
            break
        } else {
            // 현재 합이 targetN보다 작으면 end 포인터를 이동하여 합을 늘림
            currentSum += primes[end]
            end += 1
        }

        // 현재 합이 targetN과 같으면 경우의 수 증가
        if currentSum == targetN {
            count += 1
        }
    }
    return count
}

// 메인 실행 로직
let fileIO = RhynoFileIO()
let N = fileIO.readInt()

// N까지의 소수 리스트 생성
let primes = sieveOfEratosthenes(upTo: N)

// 연속된 소수 합의 경우의 수 계산 및 출력
let result = countContinuousPrimeSums(targetN: N, primes: primes)
print(result)
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
