### PR TITLE
Feat: [Swift] BOJ5639 - 이진 검색 트리

### DIFF
--- a/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
+++ b/Swift/Algorithm_Swift.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		C91845ED2E2E3E1000273165 /* Dijkstra.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91845EC2E2E3E1000273165 /* Dijkstra.swift */; };
 		C966CB402E0924AC00CB0AA4 /* MaxHeap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C966CB3F2E0924AC00CB0AA4 /* MaxHeap.swift */; };
 		C9742C282E0BC11100254991 /* AbsoluteHeap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9742C272E0BC11100254991 /* AbsoluteHeap.swift */; };
-		C9E0D3CA2E54214D0058D2FD /* 2263.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E0D3C92E54214D0058D2FD /* 2263.swift */; };
+		C9D562962E556D28009A3A18 /* 5639.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D562952E556D28009A3A18 /* 5639.swift */; };
 		C9F19BCD2E0A5D32003CEC09 /* MinHeap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F19BCC2E0A5D32003CEC09 /* MinHeap.swift */; };
 /* End PBXBuildFile section */
 
@@ -291,6 +291,7 @@
 		C9B9C6582DFA79E2008527B2 /* 11401.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11401.swift; sourceTree = "<group>"; };
 		C9CF39D02DC264F80025603C /* 24060.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 24060.swift; sourceTree = "<group>"; };
 		C9D3AFC02DC3A05E00A94E56 /* 4779.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 4779.swift; sourceTree = "<group>"; };
+		C9D562952E556D28009A3A18 /* 5639.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 5639.swift; sourceTree = "<group>"; };
 		C9D590D32E39D78F005FFF7F /* 11066.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11066.swift; sourceTree = "<group>"; };
 		C9D590D52E3B2FC7005FFF7F /* 11049.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11049.swift; sourceTree = "<group>"; };
 		C9D59AB52E288B9300985B5A /* 1766.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1766.swift; sourceTree = "<group>"; };
@@ -568,6 +569,7 @@
 				C9111DF42E518EA6001C96A1 /* 1967.swift */,
 				C9111DF62E53036C001C96A1 /* 1991.swift */,
 				C9E0D3C92E54214D0058D2FD /* 2263.swift */,
+				C9D562952E556D28009A3A18 /* 5639.swift */,
 			);
 			path = "33. 트리";
 			sourceTree = "<group>";
@@ -1241,13 +1243,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				762B87B62D20024400884CE1 /* main.swift in Sources */,
-				C9E0D3CA2E54214D0058D2FD /* 2263.swift in Sources */,
 				C9742C282E0BC11100254991 /* AbsoluteHeap.swift in Sources */,
 				765A984C2DB11C1C00B167EA /* Stack.swift in Sources */,
 				762528222DAE6B88008CCFE0 /* Deque.swift in Sources */,
 				C91845ED2E2E3E1000273165 /* Dijkstra.swift in Sources */,
 				762B87DE2D22542900884CE1 /* RhynoFileIO.swift in Sources */,
 				769986E72DAB8BE700752D17 /* Queue.swift in Sources */,
+				C9D562962E556D28009A3A18 /* 5639.swift in Sources */,
 				C9F19BCD2E0A5D32003CEC09 /* MinHeap.swift in Sources */,
 				C966CB402E0924AC00CB0AA4 /* MaxHeap.swift in Sources */,
 				762B87B82D20478C00884CE1 /* Solvable.swift in Sources */,

--- a/Swift/Algorithm_Swift/BOJ/단계별/33. 트리/5639.swift
+++ b/Swift/Algorithm_Swift/BOJ/단계별/33. 트리/5639.swift
@@ -1,0 +1,47 @@
+//
+//  5639.swift
+//  Algorithm_Swift
+//
+//  Created by 김동현 on 8/20/25.
+//
+
+//  문제 링크: https://www.acmicpc.net/problem/5639
+//  알고리즘 분류: 그래프 이론, 그래프 탐색, 트리, 재귀
+
+class BOJ5639: Solvable {
+    // 메모리: 81016KB, 시간: 60ms, 코드 길이: 637B
+    func run() {
+        // 빠른 입출력 설정
+        let fileIO = RhynoFileIO()
+        var preorder = [Int]()
+
+        // 입력: 한 줄에 하나씩, 0이 아닌 양의 정수
+        while let x = fileIO.readIntOptional() {
+            preorder.append(x)
+        }
+
+        // 후위 순회 출력 함수
+        var output = [String]()
+        func buildPostorder(_ l: Int, _ r: Int) {
+            guard l < r else { return }
+            let root = preorder[l]
+            var m = l + 1
+            // 오른쪽 서브트리 시작 인덱스 찾기
+            while m < r && preorder[m] < root {
+                m += 1
+            }
+            // 왼쪽
+            buildPostorder(l + 1, m)
+            // 오른쪽
+            buildPostorder(m, r)
+            // 루트
+            output.append(String(root))
+        }
+
+        // 전체 범위 처리
+        buildPostorder(0, preorder.count)
+
+        // 결과 출력
+        print(output.joined(separator: "\n"))
+    }
+}

--- a/Swift/Algorithm_Swift/Utility/RhynoFileIO.swift
+++ b/Swift/Algorithm_Swift/Utility/RhynoFileIO.swift
@@ -67,4 +67,24 @@ final class RhynoFileIO {
 
         return Array(buffer[beginIndex..<(index-1)])
     }
+    
+    @inline(__always) func readIntOptional() -> Int? {
+        var sum = 0
+        var now = read()
+        var isPositive = true
+        
+        // 공백/개행 스킵
+        while now == 10 || now == 32 { now = read() }
+        // EOF 센티널(0) 감지
+        if now == 0 { return nil }
+        
+        if now == 45 { isPositive.toggle(); now = read() } // 음수 처리(문제에선 양수지만 일반화)
+        var hasDigit = false
+        while now >= 48, now <= 57 {
+            hasDigit = true
+            sum = sum * 10 + Int(now - 48)
+            now = read()
+        }
+        return hasDigit ? sum * (isPositive ? 1 : -1) : nil
+    }
 }

--- a/Swift/Algorithm_Swift/main.swift
+++ b/Swift/Algorithm_Swift/main.swift
@@ -11,5 +11,5 @@
 
 import Foundation
 
-let main = BOJ2263()
+let main = BOJ5639()
 main.run()


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 Pull Request와 관련된 Issue 번호를 작성하세요 -->
- Issue 번호: #655 

---

## 🔍 문제 설명
<!-- 문제에 대한 간단한 설명을 적어주세요. -->
- **문제 이름**: BOJ5639 - 이진 검색 트리
- **사용 알고리즘**: 트리(BST), 분할 정복, 순회 변환
- **시간 복잡도**: 평균 $O(n log n)$, 최악(편향 트리) $O(n^2)$
- **문제 출처**: [문제 링크](https://www.acmicpc.net/problem/5639)
- **문제 난이도**: <img src="https://static.solved.ac/tier_small/12.svg" height="20px" /> Gold IV

---

## 📜 풀이 요약
<!-- 문제 풀이 방법을 간단하게 설명해주세요. -->
1. 빠른 입출력 설정
    - `RhynoFileIO`로 입력을 처리합니다. 전위 순회 결과를 담을 배열 `preorder`를 준비합니다.
2. 전위 순회 입력(EOF까지)
    - 버퍼 끝의 0(EOF 센티널)을 감지하는 `readIntOptional()`을 사용해 EOF까지 한 줄에 하나씩 정수를 읽어 `preorder`에 채웁니다.
3. 후위 순회 생성(분할 정복)
    - 전위 구간 `[l, r)`에서 `preorder[l]`가 **루트**입니다.
    - 루트보다 작은 연속 구간이 **왼쪽 서브트리**, 그 다음이 **오른쪽 서브트리**이므로 경계 `m`을 선형 탐색으로 찾습니다.
    - 왼쪽→오른쪽을 재귀 처리한 뒤 루트를 추가하면 **후위 순회**가 됩니다.
4. 결과 출력
    - 전체 구간을 처리하고, 후위 순회 결과를 한 줄에 하나씩 출력합니다.

---

## 💡 핵심 코드
<!-- 중요하거나 주요한 코드 블록을 첨부해주세요. -->
```swift
import Foundation

// 빠른 입출력 설정
let fileIO = RhynoFileIO()
var preorder = [Int]()

// 입력: 한 줄에 하나씩, 0이 아닌 양의 정수
while let x = fileIO.readIntOptional() {
    preorder.append(x)
}

// 후위 순회 출력 함수
var output = [String]()
func buildPostorder(_ l: Int, _ r: Int) {
    guard l < r else { return }
    let root = preorder[l]
    var m = l + 1
    // 오른쪽 서브트리 시작 인덱스 찾기
    while m < r && preorder[m] < root {
        m += 1
    }
    // 왼쪽
    buildPostorder(l + 1, m)
    // 오른쪽
    buildPostorder(m, r)
    // 루트
    output.append(String(root))
}

// 전체 범위 처리
buildPostorder(0, preorder.count)

// 결과 출력
print(output.joined(separator: "\n"))
```

---

## ✅ 체크리스트
<!-- PR 작성 시 확인해야 할 항목 -->
- [x] 문제를 해결하기 위한 알고리즘이 포함되어 있음
- [x] 테스트케이스를 통과했음
- [x] 코드에 주석을 작성했음
- [x] 문제의 요구사항에 맞게 작성했음

---

## 🤔 기타 질문 및 논의 사항
<!-- 이 Pull Request에서 논의하고 싶은 내용을 적어주세요. -->
- 

---

이 템플릿은 문제 풀이, 핵심 코드, 실행 결과 등을 체계적으로 정리할 수 있도록 설계되었습니다. 필요에 따라 추가하거나 수정할 수 있습니다.
